### PR TITLE
Update plotme-continuous-discount.jl

### DIFF
--- a/examples/unit-1-examples/time-value-of-money/plotme-continuous-discount.jl
+++ b/examples/unit-1-examples/time-value-of-money/plotme-continuous-discount.jl
@@ -27,12 +27,13 @@ for j ∈ 1:number_of_rates
 
     # iterare of period -
     for i ∈ 1:number_of_periods
-        
+        t = i - 1 # time (number of elapsed periods)
+                
         # compute the discount -
-        D = exp(r*i)
+        D = exp(r*t)
 
         # compute the future values
-        Cₒ[i,1] = i-1       # period is in the first col
+        Cₒ[i,1] = t          # period is in the first col
         Cₒ[i,j+1] = (D)*Cₜ   # future value is for each r in the col 2,... 
     end
 end


### PR DESCRIPTION
The five plotted traces should all include the point (0,1) since zero time has elapsed at period index zero.  However they do not, due to an off-by-one error in computing the value of `D`.  To clarify the reason for using `i-1` rather than `i`, I've introduced a new variable, `t`, to be the time corresponding to loop index `i`.